### PR TITLE
Call srand() to improve test reproducibility

### DIFF
--- a/knockpy/__init__.py
+++ b/knockpy/__init__.py
@@ -15,19 +15,20 @@ __all__ = [
     "KnockoffFilter",
 ]
 
-from . import constants
-from . import dgp
-from . import ggm
-from . import knockoffs
-from . import knockoff_filter
-from . import knockoff_stats
-from . import mac
-from . import metro
-from . import mlr
-from . import mrc
-from . import smatrix
-from . import utilities
-
+from . import (
+    constants,
+    dgp,
+    ggm,
+    knockoff_filter,
+    knockoff_stats,
+    knockoffs,
+    mac,
+    metro,
+    mlr,
+    mrc,
+    smatrix,
+    utilities,
+)
 from .knockoff_filter import KnockoffFilter
 
 name = "knockpy"

--- a/knockpy/dgp.py
+++ b/knockpy/dgp.py
@@ -1,15 +1,15 @@
 """A collection of functions for generating synthetic datasets."""
 
 import numpy as np
-from scipy import stats
-
-# Utility functions
-from . import utilities
-from .utilities import shift_until_PSD, cov2corr
 
 # Tree methods
 import scipy.cluster.hierarchy as hierarchy
 import scipy.spatial.distance as ssd
+from scipy import stats
+
+# Utility functions
+from . import utilities
+from .utilities import cov2corr, shift_until_PSD
 
 DEFAULT_DF_T = 3
 

--- a/knockpy/ggm.py
+++ b/knockpy/ggm.py
@@ -4,7 +4,9 @@ See https://arxiv.org/pdf/1908.11611.pdf.
 """
 
 import copy
+
 import numpy as np
+
 from .knockoff_filter import KnockoffFilter as KF
 
 

--- a/knockpy/knockoff_filter.py
+++ b/knockpy/knockoff_filter.py
@@ -1,9 +1,7 @@
 import numpy as np
-from . import utilities
-from . import knockoffs
-from . import metro
-from . import mlr
+
 from . import knockoff_stats as kstats
+from . import knockoffs, metro, mlr, utilities
 
 
 class KnockoffFilter:

--- a/knockpy/knockoff_stats.py
+++ b/knockpy/knockoff_stats.py
@@ -1,9 +1,11 @@
 import warnings
+
 import numpy as np
 
 # Model-fitters
 import sklearn
-from sklearn import linear_model, model_selection, ensemble
+from sklearn import ensemble, linear_model, model_selection
+
 from . import utilities
 from .constants import DEFAULT_REG_VALS
 

--- a/knockpy/knockoffs.py
+++ b/knockpy/knockoffs.py
@@ -1,11 +1,11 @@
 import warnings
+
 import numpy as np
-from scipy import stats
 import scipy.linalg
+from scipy import stats
 
+from . import constants, smatrix, utilities
 from .utilities import shift_until_PSD
-from . import utilities, smatrix, constants
-
 
 ### Base Knockoff Class and Gaussian Knockoffs
 

--- a/knockpy/kpytorch/deeppink.py
+++ b/knockpy/kpytorch/deeppink.py
@@ -1,7 +1,7 @@
 import numpy as np
-
 import torch
 import torch.nn as nn
+
 from .. import utilities
 
 

--- a/knockpy/kpytorch/mrcgrad.py
+++ b/knockpy/kpytorch/mrcgrad.py
@@ -2,14 +2,14 @@
 Currently only used for group-knockoffs."""
 
 import warnings
+
 import numpy as np
 import scipy as sp
-
 import torch
 import torch.nn as nn
 
+from .. import mrc, utilities
 from ..constants import GAMMA_VALS
-from .. import utilities, mrc
 
 
 def block_diag_sparse(*arrs):

--- a/knockpy/mac.py
+++ b/knockpy/mac.py
@@ -1,13 +1,13 @@
 import warnings
+
+# For SDP
+import cvxpy as cp
 import numpy as np
 import scipy as sp
 import scipy.linalg
 
+from . import constants, utilities
 from .constants import DEFAULT_TOL
-from . import utilities, constants
-
-# For SDP
-import cvxpy as cp
 
 try:
     from pydsdp.dsdp5 import dsdp

--- a/knockpy/metro.py
+++ b/knockpy/metro.py
@@ -10,22 +10,22 @@ This code was based on initial code written by Stephen Bates in October
 """
 
 # The basics
-import numpy as np
-import scipy as sp
-import scipy.special
 import itertools
-from functools import reduce
-from . import utilities, dgp
-
-# Network and UGM tools
-import networkx as nx
-from networkx.algorithms.approximation import treewidth
-from .knockoffs import KnockoffSampler
-from . import smatrix, constants
 
 # Logging
 import warnings
+from functools import reduce
+
+# Network and UGM tools
+import networkx as nx
+import numpy as np
+import scipy as sp
+import scipy.special
+from networkx.algorithms.approximation import treewidth
 from tqdm import tqdm
+
+from . import constants, dgp, smatrix, utilities
+from .knockoffs import KnockoffSampler
 
 
 def gaussian_log_likelihood(X, mu, var):

--- a/knockpy/mlr/__init__.py
+++ b/knockpy/mlr/__init__.py
@@ -9,4 +9,4 @@ __all__ = [
 ]
 
 from . import mlr
-from .mlr import MLR_Spikeslab, MLR_FX_Spikeslab, MLR_Spikeslab_Splines, OracleMLR
+from .mlr import MLR_FX_Spikeslab, MLR_Spikeslab, MLR_Spikeslab_Splines, OracleMLR

--- a/knockpy/mlr/mlr.py
+++ b/knockpy/mlr/mlr.py
@@ -4,12 +4,13 @@ Note to self: should this be in "knockoff_stats.py"?
 
 import numpy as np
 import scipy.special
-from ._mlr_spikeslab_fx import _sample_mlr_spikeslab_fx
-from ._mlr_spikeslab import _sample_mlr_spikeslab
-from ._mlr_spikeslab_group import _sample_mlr_spikeslab_group
-from ._mlr_oracle import _sample_mlr_oracle_gaussian, _sample_mlr_oracle_logistic
+
 from .. import knockoff_stats as kstats
 from .. import utilities
+from ._mlr_oracle import _sample_mlr_oracle_gaussian, _sample_mlr_oracle_logistic
+from ._mlr_spikeslab import _sample_mlr_spikeslab
+from ._mlr_spikeslab_fx import _sample_mlr_spikeslab_fx
+from ._mlr_spikeslab_group import _sample_mlr_spikeslab_group
 
 
 def check_no_groups(groups, p, error=None):

--- a/knockpy/mrc.py
+++ b/knockpy/mrc.py
@@ -1,10 +1,12 @@
 """Methods for minimum-reconstructability knockoffs."""
 
-import warnings
 import time
+import warnings
+
 import numpy as np
 import scipy as sp
-from . import utilities, constants, mac
+
+from . import constants, mac, utilities
 
 try:
     import choldate

--- a/knockpy/smatrix.py
+++ b/knockpy/smatrix.py
@@ -1,10 +1,7 @@
 import numpy as np
 import scipy.cluster.hierarchy as hierarchy
-from . import mrc
-from . import mac
-from . import dgp
-from . import utilities
-from . import constants
+
+from . import constants, dgp, mac, mrc, utilities
 
 # These methods don't require approximation
 NON_APPROX_METHODS = ["equicorrelated", "eq", "ci", "ciknock"]

--- a/knockpy/utilities.py
+++ b/knockpy/utilities.py
@@ -439,6 +439,10 @@ def check_pyglmnet_available(purpose):
 
 
 def srand(val: int) -> None:
+    """
+    Some knockpy functions invoke the C rand() function to generate random numbers. Invoking
+    srand() with some fixed value can help ensure repeatable results.
+    """
     libc = ctypes.CDLL(None)
     libc.srand.argtypes = [ctypes.c_uint]
     libc.srand(val)

--- a/knockpy/utilities.py
+++ b/knockpy/utilities.py
@@ -1,11 +1,13 @@
+import ctypes
 import warnings
+from functools import partial
+from multiprocessing import Pool
+
 import numpy as np
 import scipy as sp
 import scipy.sparse.linalg
-from scipy.sparse.linalg import eigsh
 import sklearn.covariance
-from multiprocessing import Pool
-from functools import partial
+from scipy.sparse.linalg import eigsh
 
 
 ### Group helpers
@@ -434,3 +436,9 @@ def check_pyglmnet_available(purpose):
         raise ValueError(
             f"pyglmnet is required for {purpose}, but importing pyglmnet raised {err}. See https://github.com/glm-tools/pyglmnet/."
         )
+
+
+def srand(val: int) -> None:
+    libc = ctypes.CDLL(None)
+    libc.srand.argtypes = [ctypes.c_uint]
+    libc.srand(val)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,6 @@ markers = [
 exclude = [
   "docs/",
 ]
+
+[tool.ruff.lint]
+extend-select = ["I"]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-import numpy as np
 import os
+
+import numpy as np
 import setuptools
 from setuptools import Extension
 

--- a/test/test_dgp.py
+++ b/test/test_dgp.py
@@ -1,9 +1,10 @@
-import numpy as np
-import scipy as sp
 import unittest
-import pytest
-import knockpy
 
+import numpy as np
+import pytest
+import scipy as sp
+
+import knockpy
 from knockpy import dgp
 
 
@@ -694,8 +695,9 @@ class TestGroupings(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import pytest
     import sys
+
+    import pytest
 
     pytest.main(sys.argv)
     # unittest.main()

--- a/test/test_ggm.py
+++ b/test/test_ggm.py
@@ -1,5 +1,6 @@
-import numpy as np
 import unittest
+
+import numpy as np
 import pytest
 
 from knockpy import ggm
@@ -75,8 +76,9 @@ class TestGGM(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import pytest
     import sys
+
+    import pytest
 
     pytest.main(sys.argv)
     # unittest.main()

--- a/test/test_knockoff_filter.py
+++ b/test/test_knockoff_filter.py
@@ -1,16 +1,15 @@
 import os
 import time
-import pytest
-import numpy as np
 import unittest
+
+import numpy as np
+import pytest
 from scipy import stats
 
 import knockpy
 from knockpy import dgp, utilities
 from knockpy.knockoff_filter import KnockoffFilter
-
-from test.utilities import srand
-
+from knockpy.utilities import srand
 
 file_directory = os.path.dirname(os.path.abspath(__file__))
 

--- a/test/test_knockoff_filter.py
+++ b/test/test_knockoff_filter.py
@@ -2,12 +2,14 @@ import os
 import time
 import pytest
 import numpy as np
-from scipy import stats
 import unittest
-import knockpy
+from scipy import stats
 
+import knockpy
 from knockpy import dgp, utilities
 from knockpy.knockoff_filter import KnockoffFilter
+
+from test.utilities import srand
 
 
 file_directory = os.path.dirname(os.path.abspath(__file__))
@@ -494,6 +496,7 @@ class TestKnockoffFilter(TestFdrControl):
     @pytest.mark.quick
     def test_mlr_fit(self):
         """Tests that MLR statistics work"""
+        srand(42)
         n = 200
         p = 50
         # 1. FX

--- a/test/test_knockoff_stats.py
+++ b/test/test_knockoff_stats.py
@@ -1,15 +1,14 @@
-import numpy as np
 import unittest
+
+import numpy as np
 import sklearn.naive_bayes
 import sklearn.neural_network
 
 import knockpy
+from knockpy import dgp, utilities
 from knockpy import knockoff_stats as kstats
-from knockpy import utilities, dgp
 from knockpy.knockoff_stats import data_dependent_threshhold
-
-from test.utilities import srand
-
+from knockpy.utilities import srand
 
 try:
     import torch as torch
@@ -883,8 +882,9 @@ class TestHelpers(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    import pytest
     import sys
+
+    import pytest
 
     pytest.main(sys.argv)
     # unittest.main()

--- a/test/test_knockoff_stats.py
+++ b/test/test_knockoff_stats.py
@@ -8,6 +8,9 @@ from knockpy import knockoff_stats as kstats
 from knockpy import utilities, dgp
 from knockpy.knockoff_stats import data_dependent_threshhold
 
+from test.utilities import srand
+
+
 try:
     import torch as torch
 
@@ -816,6 +819,7 @@ class TestDataThreshhold(unittest.TestCase):
                 self.check_T(W, T, q)
 
     def test_batched(self):
+        srand(42)
         q = 0.2
         W1 = np.array([1] * 10)
         W2 = np.array([-2, -1, 1, 2, 3, 4, 5, 6, 7, 8])
@@ -834,6 +838,7 @@ class TestDataThreshhold(unittest.TestCase):
     def test_zero_handling(self):
         """Makes sure Ts != 0"""
 
+        srand(42)
         q = 0.2
         W1 = np.array([1] * 10 + [0] * 10)
         W2 = np.array([-2, -1, 1, 2, 3, 4, 5, 6, 7, 8] + [0] * 10)

--- a/test/test_knockoffs.py
+++ b/test/test_knockoffs.py
@@ -6,6 +6,7 @@ import unittest
 
 import knockpy
 from knockpy import dgp, utilities, mac, mrc, smatrix, knockoffs
+from test.utilities import srand
 
 try:
     import torch as torch
@@ -266,6 +267,8 @@ class TestSDP(CheckSMatrix):
         )
 
     def test_sdp_tolerance(self):
+        srand(42)
+
         # Get graph
         np.random.seed(110)
         Q = dgp.ErdosRenyi(p=50, tol=1e-1)

--- a/test/test_knockoffs.py
+++ b/test/test_knockoffs.py
@@ -1,12 +1,13 @@
 """Tests knockpy.knockoffs and knockpy.smatrix modules"""
 
-import warnings
-import numpy as np
 import unittest
+import warnings
+
+import numpy as np
 
 import knockpy
-from knockpy import dgp, utilities, mac, mrc, smatrix, knockoffs
-from test.utilities import srand
+from knockpy import dgp, knockoffs, mac, mrc, smatrix, utilities
+from knockpy.utilities import srand
 
 try:
     import torch as torch
@@ -1163,8 +1164,9 @@ class TestKnockoffGen(CheckValidKnockoffs):
 
 
 if __name__ == "__main__":
-    import pytest
     import sys
+
+    import pytest
 
     pytest.main(sys.argv)
     # unittest.main()

--- a/test/test_metro.py
+++ b/test/test_metro.py
@@ -6,10 +6,12 @@ from scipy import stats
 import unittest
 import knockpy
 from knockpy import dgp, metro
+from test.utilities import srand
 
 
 class TestMetroProposal(unittest.TestCase):
     def test_gaussian_likelihood(self):
+        srand(24)
         X = np.array([0.5, 1, 2, 3])
         mu = 0.5
         var = 0.2
@@ -28,6 +30,7 @@ class TestMetroProposal(unittest.TestCase):
     def test_proposal_covs(self):
         # Fake data
         np.random.seed(110)
+        srand(42)
         n = 5
         p = 200
         dgprocess = dgp.DGP()
@@ -82,6 +85,7 @@ class TestMetroSample(unittest.TestCase):
     def test_ar1_sample(self):
         # Fake data
         np.random.seed(110)
+        srand(42)
         n = 30000
         p = 8
         dgprocess = dgp.DGP()

--- a/test/test_metro.py
+++ b/test/test_metro.py
@@ -1,12 +1,14 @@
 import os
-import numpy as np
+import unittest
+
 import networkx as nx
+import numpy as np
 from networkx.algorithms.approximation import treewidth
 from scipy import stats
-import unittest
+
 import knockpy
 from knockpy import dgp, metro
-from test.utilities import srand
+from knockpy.utilities import srand
 
 
 class TestMetroProposal(unittest.TestCase):

--- a/test/test_mlr.py
+++ b/test/test_mlr.py
@@ -1,7 +1,8 @@
-import numpy as np
 import unittest
-import knockpy
 
+import numpy as np
+
+import knockpy
 from knockpy import knockoffs, mlr, utilities
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,8 @@
-import numpy as np
-import scipy as sp
 import unittest
 import warnings
+
+import numpy as np
+import scipy as sp
 
 from knockpy import dgp, utilities
 

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -1,0 +1,7 @@
+import ctypes
+
+
+def srand(val: int) -> None:
+    libc = ctypes.CDLL(None)
+    libc.srand.argtypes = [ctypes.c_uint]
+    libc.srand(val)

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -1,7 +1,0 @@
-import ctypes
-
-
-def srand(val: int) -> None:
-    libc = ctypes.CDLL(None)
-    libc.srand.argtypes = [ctypes.c_uint]
-    libc.srand(val)


### PR DESCRIPTION
This PR:
- provides `srand()` to make invoking knockpy functions more reproducible.
- improves test reproducibility by calling `srand()`.
- cleans up imports